### PR TITLE
Added a function to check if an object is an IError object

### DIFF
--- a/packages/ErrorModule/src/Error.ts
+++ b/packages/ErrorModule/src/Error.ts
@@ -32,6 +32,14 @@ export class ErrorModule {
         return error;
     }
 
+    /**
+     * isError
+     * @description Check if the object is an IError object
+     * @param error object you want to test
+     */
+    public isError(error: object): boolean {
+        return (error && error.hasOwnProperty('code') && error.hasOwnProperty('why') && error.hasOwnProperty('from'));
+    }
 }
 
 export interface ErrorContent {

--- a/packages/ErrorModule/tests/__tests__/ErrorModule.spec.ts
+++ b/packages/ErrorModule/tests/__tests__/ErrorModule.spec.ts
@@ -59,4 +59,30 @@ describe("Integration Test", () => {
         });
     });
 
+    describe("IsError", () => {
+
+        let inject: Injector;
+
+        beforeEach(() => {
+            inject = new Injector;
+        });
+
+        it("Should fail because the object is not an IError object", () => {
+            let errorModule = inject.inject(ErrorModule);
+            const error = {foo: "bar"};
+
+            expect(errorModule.isError(error)).toBe(false);
+        });
+
+        it("Should pass because the object is an IError object", () => {
+            let errorModule = inject.inject(ErrorModule);
+            const error = {
+                code: "200",
+                why: "foo",
+                from: "bar"
+            };
+
+            expect(errorModule.isError(error)).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
## Why this PR?
Added the feature of this issue: #2 
## Changes:
 - Added a new function: `isError` to check if an object is an IError one.

